### PR TITLE
fixed customer name inside package-list

### DIFF
--- a/src/component/Package-List/CreatePackage.js
+++ b/src/component/Package-List/CreatePackage.js
@@ -104,10 +104,7 @@ function CreatePackage() {
                 <MenuItem value="">
                   <em>select</em>
                 </MenuItem>
-                <MenuItem value={"Dave"}>Dave</MenuItem>
-                <MenuItem value={"Sarah"}>Sarah</MenuItem>
-                <MenuItem value={"Otis"}>Otis</MenuItem>
-                <MenuItem value={"Marry"}>Marry</MenuItem>
+                {customers.map((customer)=><MenuItem value={customer.name}>{customer.name}</MenuItem>)}
               </Select>
             </FormControl>
 


### PR DESCRIPTION
## Changes
Added "map" to the names in "CreatePackages"'s select area

## Reason for changes
When deleting a customer, his/her name is still inside the select area and you can choose it even though this person doesn't exist anymore in the system