### PR TITLE
fix:price added as string, not number

### DIFF
--- a/src/component/Invoices/utils.js
+++ b/src/component/Invoices/utils.js
@@ -1,6 +1,6 @@
 export function PriceSum(id, packages) {
   let count = 0;
-  packages.filter((packages) => packages.customerid === id).forEach((value) => { count += value.price })
+  packages.filter((packages) => packages.customerid === id).forEach((value) => { count += parseInt(value.price)})
   return count
 }
 


### PR DESCRIPTION
## Changes
Convert price from string to int

## Reason changes
When a package is added, the price comes out wrong